### PR TITLE
fix maths overflowing on narrow screens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -155,6 +155,31 @@ pre code {
   font-size: inherit;
 }
 
+/* KaTeX display math - allow horizontal scroll for long equations */
+.katex-display {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-nav-background) transparent;
+}
+
+.katex-display::-webkit-scrollbar {
+  height: 6px;
+}
+
+.katex-display::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.katex-display::-webkit-scrollbar-thumb {
+  background-color: var(--color-nav-background);
+  border-radius: 3px;
+}
+
+.katex-display::-webkit-scrollbar-thumb:hover {
+  background-color: #e09a16;
+}
+
 /* Syntax highlighting overrides for better contrast */
 .hljs {
   background: var(--color-code-bg) !important;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable horizontal scrolling and custom scrollbar styling for `katex-display` to prevent math overflow on narrow screens.
> 
> - **Styles (globals.css)**:
>   - **KaTeX display math**: Add horizontal scrolling (`overflow-x: auto`) and custom scrollbar styling for `.katex-display` to avoid overflow on small screens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aefe3f98cb95d346981274ba7f03e36f610eaafb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->